### PR TITLE
環境変数FORCE_SSLがtrueの時はhttpsを強制する

### DIFF
--- a/app.js
+++ b/app.js
@@ -21,6 +21,11 @@ app.use(bodyParser.json());
 app.use(bodyParser.urlencoded({ extended: false }));
 app.use(express.static(path.join(__dirname, 'public')));
 
+var forceSSL = require('express-force-ssl')
+if (process.env.FORCE_SSL === 'true') {
+  app.use(forceSSL)
+}
+
 app.use('/', routes);
 app.use('/users', users);
 

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "crypto": "0.0.3",
     "debug": "^2.2.0",
     "express": "~4.13.1",
+    "express-force-ssl": "^0.3.2",
     "formidable": "1.0.14",
     "jade": "~1.11.0",
     "morgan": "~1.6.1",


### PR DESCRIPTION
## 問題
gyaon.herokuapp.com をブラウザのURL欄に打ち込んで開くとhttpで開いてしまって、録音できない

## これで解決
[experss-force-ssl](https://github.com/battlejj/express-force-ssl)
httpで来たらhttpsにリダイレクトする

## herokuで有効にする
環境変数FORCE_SSLがtrueの時のみ有効になるので
```
$ heroku config:set FORCE_SSL=true
```
する必要がある